### PR TITLE
feat: 프롬프트 목록/상세 API에 isLiked 필드 추가

### DIFF
--- a/src/main/java/com/promlog/promlog/prompt/controller/PromptController.java
+++ b/src/main/java/com/promlog/promlog/prompt/controller/PromptController.java
@@ -36,18 +36,24 @@ public class PromptController {
 
     @GetMapping
     public ApiResponse<PromptListResponse> list(
+            Authentication authentication, // ✅ 추가 (로그인 안 하면 null)
             @RequestParam(required = false, defaultValue = "latest") String sort,
             @RequestParam(required = false, defaultValue = "1") int page,
             @RequestParam(required = false, defaultValue = "20") int size,
             @RequestParam(required = false) List<Long> categoryIds,
             @RequestParam(required = false) List<Long> platformIds
     ) {
-        return ApiResponse.ok(promptService.list(sort, page, size, categoryIds, platformIds));
+        Long viewerAccountId = (authentication == null) ? null : (long) authentication.getPrincipal();
+        return ApiResponse.ok(promptService.list(viewerAccountId, sort, page, size, categoryIds, platformIds));
     }
 
     @GetMapping("/{promptId}")
-    public ApiResponse<PromptResponse> detail(@PathVariable Long promptId) {
-        return ApiResponse.ok(promptService.getDetail(promptId));
+    public ApiResponse<PromptResponse> detail(
+            Authentication authentication, // ✅ 추가 (로그인 안 하면 null)
+            @PathVariable Long promptId
+    ) {
+        Long viewerAccountId = (authentication == null) ? null : (long) authentication.getPrincipal();
+        return ApiResponse.ok(promptService.getDetail(viewerAccountId, promptId));
     }
 
     @PatchMapping("/{promptId}")

--- a/src/main/java/com/promlog/promlog/prompt/dto/PromptResponse.java
+++ b/src/main/java/com/promlog/promlog/prompt/dto/PromptResponse.java
@@ -37,7 +37,8 @@ public record PromptResponse(
     public record Stats(
             int likeCount,
             long viewCount,
-            long copyCount
+            long copyCount,
+            boolean isLiked // ✅ 추가
     ) {}
 
     // 🏷 카테고리/플랫폼 그룹
@@ -46,7 +47,13 @@ public record PromptResponse(
             List<TagDto> platforms
     ) {}
 
+    // ✅ 기존 호출부 호환용 (기본값: false)
     public static PromptResponse from(Prompt p) {
+        return from(p, false);
+    }
+
+    // ✅ 신규: 로그인 사용자의 좋아요 여부까지 포함
+    public static PromptResponse from(Prompt p, boolean isLiked) {
         boolean anonymous = p.isAnonymous();
         String nickname = anonymous ? null : p.getAuthor().getNickname();
 
@@ -70,7 +77,7 @@ public record PromptResponse(
                 p.getId(),
                 p.getStatus(),
                 new Author(
-                        p.getAuthorAccountId(),
+                        p.getAuthorAccountId(), // 익명이어도 id를 내려줄지 정책에 따라 바꿔도 됨
                         nickname,
                         anonymous
                 ),
@@ -85,7 +92,8 @@ public record PromptResponse(
                 new Stats(
                         p.getLikeCount(),
                         p.getViewCount(),
-                        p.getCopyCount()
+                        p.getCopyCount(),
+                        isLiked
                 ),
                 new Tags(categories, platforms)
         );

--- a/src/main/java/com/promlog/promlog/prompt/repository/PromptLikeRepository.java
+++ b/src/main/java/com/promlog/promlog/prompt/repository/PromptLikeRepository.java
@@ -7,25 +7,52 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface PromptLikeRepository extends JpaRepository<PromptLike, PromptLikeId> {
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    // ✅ (이미 너가 쓰고 있는 메서드들) - 시그니처는 기존 그대로 유지
+    @Modifying(clearAutomatically = true)
     @Query(value = """
-        INSERT INTO prompt_likes (prompt_id, account_id, deleted_at)
-        VALUES (:promptId, :accountId, NULL)
-        ON DUPLICATE KEY UPDATE deleted_at = NULL
+        INSERT INTO prompt_likes (prompt_id, account_id, created_at, updated_at, deleted_at)
+        VALUES (:promptId, :accountId, NOW(3), NOW(3), NULL)
+        ON DUPLICATE KEY UPDATE
+            deleted_at = NULL,
+            updated_at = NOW(3)
         """, nativeQuery = true)
-    int like(@Param("promptId") Long promptId,
-             @Param("accountId") Long accountId);
+    int like(@Param("promptId") long promptId, @Param("accountId") long accountId);
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying(clearAutomatically = true)
     @Query(value = """
         UPDATE prompt_likes
-           SET deleted_at = NOW(3)
+           SET deleted_at = NOW(3),
+               updated_at = NOW(3)
          WHERE prompt_id = :promptId
            AND account_id = :accountId
            AND deleted_at IS NULL
         """, nativeQuery = true)
-    int unlike(@Param("promptId") Long promptId,
-               @Param("accountId") Long accountId);
+    int unlike(@Param("promptId") long promptId, @Param("accountId") long accountId);
+
+    // ✅ 단건: detail에서 사용
+    @Query("""
+        select (count(pl) > 0)
+          from PromptLike pl
+         where pl.id.promptId = :promptId
+           and pl.id.accountId = :accountId
+           and pl.deletedAt is null
+    """)
+    boolean existsActive(@Param("promptId") long promptId, @Param("accountId") long accountId);
+
+    // ✅ 다건: list에서 사용 (현재 페이지 promptIds 대상으로 한 번에 조회)
+    @Query("""
+        select pl.id.promptId
+          from PromptLike pl
+         where pl.id.accountId = :accountId
+           and pl.id.promptId in :promptIds
+           and pl.deletedAt is null
+    """)
+    List<Long> findActiveLikedPromptIds(
+            @Param("accountId") long accountId,
+            @Param("promptIds") List<Long> promptIds
+    );
 }

--- a/src/main/java/com/promlog/promlog/prompt/service/PromptService.java
+++ b/src/main/java/com/promlog/promlog/prompt/service/PromptService.java
@@ -53,12 +53,7 @@ public class PromptService {
     public PromptResponse create(long accountId, PromptCreateRequest req) {
 
         Account author = accountRepository.findById(accountId)
-                .orElseThrow(() ->
-                        new BusinessException(
-                                ErrorCode.NOT_FOUND,
-                                "작성자 계정을 찾을 수 없습니다."
-                        )
-                );
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "작성자 계정을 찾을 수 없습니다."));
 
         Prompt prompt = new Prompt(
                 author,
@@ -95,11 +90,11 @@ public class PromptService {
                 .findDetailWithAuthorAndTags(saved.getId(), PromptStatus.DELETED)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "프롬프트를 찾을 수 없습니다."));
 
-        return PromptResponse.from(refreshed);
+        return PromptResponse.from(refreshed, false);
     }
 
     @Transactional(readOnly = true)
-    public PromptListResponse list(String sort, int page, int size,
+    public PromptListResponse list(Long viewerAccountId, String sort, int page, int size,
                                    List<Long> categoryIds, List<Long> platformIds) {
 
         if (page < 1) throw new BusinessException(ErrorCode.VALIDATION_ERROR, "page는 1 이상이어야 합니다.");
@@ -130,9 +125,21 @@ public class PromptService {
 
         var result = promptRepository.findAll(spec, pageable);
 
+        // ✅ 지금 페이지에 있는 promptId들 추출
+        List<Long> promptIds = result.getContent().stream()
+                .map(Prompt::getId)
+                .filter(Objects::nonNull)
+                .toList();
+
+        // ✅ 핵심: likedPromptIds를 "재할당 없이" final로 한 번에 만들기
+        final Set<Long> likedPromptIds =
+                (viewerAccountId == null || promptIds.isEmpty())
+                        ? Collections.emptySet()
+                        : new HashSet<>(promptLikeRepository.findActiveLikedPromptIds(viewerAccountId, promptIds));
+
         List<PromptResponse> items = result.getContent()
                 .stream()
-                .map(PromptResponse::from)
+                .map(p -> PromptResponse.from(p, likedPromptIds.contains(p.getId())))
                 .toList();
 
         PageMeta meta = new PageMeta(
@@ -147,7 +154,7 @@ public class PromptService {
     }
 
     @Transactional
-    public PromptResponse getDetail(Long promptId) {
+    public PromptResponse getDetail(Long viewerAccountId, Long promptId) {
 
         int updated = promptRepository.increaseViewCount(promptId);
         if (updated == 0) {
@@ -158,7 +165,12 @@ public class PromptService {
                 .findDetailWithAuthorAndTags(promptId, PromptStatus.DELETED)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "프롬프트를 찾을 수 없습니다."));
 
-        return PromptResponse.from(prompt);
+        boolean isLiked = false;
+        if (viewerAccountId != null) {
+            isLiked = promptLikeRepository.existsActive(promptId, viewerAccountId);
+        }
+
+        return PromptResponse.from(prompt, isLiked);
     }
 
     @Transactional
@@ -207,7 +219,7 @@ public class PromptService {
                 .findDetailWithAuthorAndTags(promptId, PromptStatus.DELETED)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "프롬프트를 찾을 수 없습니다."));
 
-        return PromptResponse.from(refreshed);
+        return PromptResponse.from(refreshed, false);
     }
 
     @Transactional
@@ -244,12 +256,8 @@ public class PromptService {
     @Transactional(readOnly = true)
     public PromptListResponse listMine(long accountId, int page, int size) {
 
-        if (page < 1) {
-            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "page는 1 이상이어야 합니다.");
-        }
-        if (size < 1 || size > 50) {
-            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "size는 1~50 이어야 합니다.");
-        }
+        if (page < 1) throw new BusinessException(ErrorCode.VALIDATION_ERROR, "page는 1 이상이어야 합니다.");
+        if (size < 1 || size > 50) throw new BusinessException(ErrorCode.VALIDATION_ERROR, "size는 1~50 이어야 합니다.");
 
         PageRequest pageable = PageRequest.of(
                 page - 1,
@@ -265,7 +273,7 @@ public class PromptService {
 
         var items = result.getContent()
                 .stream()
-                .map(PromptResponse::from)
+                .map(p -> PromptResponse.from(p, false))
                 .toList();
 
         PageMeta meta = new PageMeta(
@@ -313,6 +321,36 @@ public class PromptService {
         return new LikeResponse(false, likeCount);
     }
 
+    @Transactional(readOnly = true)
+    public PromptListResponse listLiked(long accountId, int page, int size) {
+
+        if (page < 1) throw new BusinessException(ErrorCode.VALIDATION_ERROR, "page는 1 이상이어야 합니다.");
+        if (size < 1 || size > 50) throw new BusinessException(ErrorCode.VALIDATION_ERROR, "size는 1~50 이어야 합니다.");
+
+        PageRequest pageable = PageRequest.of(
+                page - 1,
+                size,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        var result = promptRepository.findLikedPrompts(accountId, PromptStatus.DELETED, pageable);
+
+        var items = result.getContent()
+                .stream()
+                .map(p -> PromptResponse.from(p, true))
+                .toList();
+
+        PageMeta meta = new PageMeta(
+                page,
+                size,
+                result.getTotalElements(),
+                result.getTotalPages(),
+                result.hasNext()
+        );
+
+        return new PromptListResponse(items, meta);
+    }
+
     /* ===============================
        helpers
        =============================== */
@@ -335,39 +373,4 @@ public class PromptService {
             );
         }
     }
-
-    @Transactional(readOnly = true)
-    public PromptListResponse listLiked(long accountId, int page, int size) {
-
-        if (page < 1) {
-            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "page는 1 이상이어야 합니다.");
-        }
-        if (size < 1 || size > 50) {
-            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "size는 1~50 이어야 합니다.");
-        }
-
-        PageRequest pageable = PageRequest.of(
-                page - 1,
-                size,
-                Sort.by(Sort.Direction.DESC, "createdAt") // 좋아요 “최신순”
-        );
-
-        var result = promptRepository.findLikedPrompts(accountId, PromptStatus.DELETED, pageable);
-
-        var items = result.getContent()
-                .stream()
-                .map(PromptResponse::from)
-                .toList();
-
-        PageMeta meta = new PageMeta(
-                page,
-                size,
-                result.getTotalElements(),
-                result.getTotalPages(),
-                result.hasNext()
-        );
-
-        return new PromptListResponse(items, meta);
-    }
-
 }


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 로그인 사용자 기준 좋아요 여부 계산
- [x] 페이지 단위로 liked promptId 일괄 조회 (N+1 방지)
- [x] 비로그인 시 isLiked=false 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* **개인화된 좋아요 상태 표시**
  * 인증된 사용자가 프롬프트 목록 및 상세 조회 시 자신이 좋아요한 프롬프트를 구분할 수 있도록 개선되었습니다.

## 개선사항

* **API 엔드포인트 강화**
  * 목록 및 상세 조회 엔드포인트가 사용자 인증 정보를 활용하여 개인화된 응답을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->