### PR TITLE
refactor: 좋아요 카운트 증가 로직을 DB 트리거에 위임

### DIFF
--- a/src/main/java/com/promlog/promlog/prompt/service/PromptService.java
+++ b/src/main/java/com/promlog/promlog/prompt/service/PromptService.java
@@ -125,13 +125,11 @@ public class PromptService {
 
         var result = promptRepository.findAll(spec, pageable);
 
-        // ✅ 지금 페이지에 있는 promptId들 추출
         List<Long> promptIds = result.getContent().stream()
                 .map(Prompt::getId)
                 .filter(Objects::nonNull)
                 .toList();
 
-        // ✅ 핵심: likedPromptIds를 "재할당 없이" final로 한 번에 만들기
         final Set<Long> likedPromptIds =
                 (viewerAccountId == null || promptIds.isEmpty())
                         ? Collections.emptySet()
@@ -296,11 +294,8 @@ public class PromptService {
         promptRepository.findByIdAndDeletedAtIsNullAndStatusNot(promptId, PromptStatus.DELETED)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "프롬프트를 찾을 수 없습니다."));
 
-        int affected = promptLikeRepository.like(promptId, accountId);
-
-        if (affected > 0) {
-            promptRepository.increaseLikeCount(promptId);
-        }
+        // ✅ 트리거가 like_count를 관리하므로, 서비스에서 카운트 증감하지 않음
+        promptLikeRepository.like(promptId, accountId);
 
         int likeCount = promptRepository.findLikeCountOrZero(promptId);
         return new LikeResponse(true, likeCount);
@@ -311,11 +306,8 @@ public class PromptService {
         promptRepository.findByIdAndDeletedAtIsNullAndStatusNot(promptId, PromptStatus.DELETED)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "프롬프트를 찾을 수 없습니다."));
 
-        int affected = promptLikeRepository.unlike(promptId, accountId);
-
-        if (affected == 1) {
-            promptRepository.decreaseLikeCount(promptId);
-        }
+        // ✅ 트리거가 like_count를 관리하므로, 서비스에서 카운트 증감하지 않음
+        promptLikeRepository.unlike(promptId, accountId);
 
         int likeCount = promptRepository.findLikeCountOrZero(promptId);
         return new LikeResponse(false, likeCount);


### PR DESCRIPTION
## ✅ 체크리스트

- [v] 서비스 레이어에서 likeCount 증감 제거
- [v] 중복 증가(+2) 문제 해결


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 좋아요 기능의 처리 로직을 최적화하였습니다. 서비스 계층의 불필요한 카운트 업데이트 로직을 제거하고 데이터베이스 트리거를 활용하여 좋아요 수를 관리하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->