### PR TITLE
feat: 로그아웃 API 추가 (refresh_token 쿠키 삭제)

### DIFF
--- a/src/main/java/com/promlog/promlog/auth/controller/AuthController.java
+++ b/src/main/java/com/promlog/promlog/auth/controller/AuthController.java
@@ -1,11 +1,14 @@
 package com.promlog.promlog.auth.controller;
 
-import com.promlog.promlog.auth.dto.RefreshRequest;
 import com.promlog.promlog.auth.dto.RefreshResponse;
 import com.promlog.promlog.auth.service.AuthService;
 import com.promlog.promlog.global.response.ApiResponse;
-import jakarta.validation.Valid;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -22,5 +25,25 @@ public class AuthController {
             @CookieValue(name = "refresh_token", required = false) String refreshToken
     ) {
         return ApiResponse.ok(authService.refreshAccessToken(refreshToken));
+    }
+
+    /**
+     * ✅ 로그아웃: refresh_token 쿠키 삭제만 수행
+     * (로그인 때와 동일 옵션으로 삭제해야 정상 제거됨)
+     */
+    @PostMapping("/logout")
+    public ApiResponse<?> logout(HttpServletResponse response) {
+
+        ResponseCookie deleteRefreshCookie = ResponseCookie.from("refresh_token", "")
+                .httpOnly(true)
+                .secure(false)              // 로그인 때와 동일 (로컬 기준)
+                .path("/api/auth")          // 로그인 때와 동일
+                .sameSite("Lax")            // 로그인 때와 동일
+                .maxAge(0)                  // 즉시 만료
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, deleteRefreshCookie.toString());
+
+        return ApiResponse.ok(Map.of("loggedOut", true));
     }
 }


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 로그아웃 API 추가 (refresh_token 쿠키 삭제)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 사용자 로그아웃 기능이 추가되었습니다. 로그아웃 시 인증 정보가 안전하게 삭제되며, 로그아웃이 완료되었음을 확인하는 응답을 받게 됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->