### PR TITLE
feat: 카카오 OAuth 로그인에 redirectUri 파라미터 지원 추가

### DIFF
--- a/src/main/java/com/promlog/promlog/auth/controller/OAuthController.java
+++ b/src/main/java/com/promlog/promlog/auth/controller/OAuthController.java
@@ -39,37 +39,45 @@ public class OAuthController {
 
     // ✅ 프론트가 code 받는 경우: 이 콜백은 이제 "프론트"로 감
     // 그래서 이 엔드포인트는 거의 안 쓰게 됨(남겨도 되는데 실제로는 호출 안 됨)
-    @GetMapping("/kakao/callback")
-    public ApiResponse<?> kakaoCallback(
-            @RequestParam(required = false) String code,
-            @RequestParam(required = false) String error,
-            @RequestParam(required = false, name = "error_description") String errorDescription
-    ) {
-        if (code == null || code.isBlank()) {
-            throw new BusinessException(
-                    ErrorCode.VALIDATION_ERROR,
-                    "카카오 인증 실패 또는 취소",
-                    java.util.Map.of(
-                            "error", error,
-                            "errorDescription", errorDescription
-                    )
-            );
-        }
-        return ApiResponse.ok(oauthService.kakaoLogin(code));
-    }
+//    @GetMapping("/kakao/callback")
+//    public ApiResponse<?> kakaoCallback(
+//            @RequestParam(required = false) String code,
+//            @RequestParam(required = false) String error,
+//            @RequestParam(required = false, name = "error_description") String errorDescription
+//    ) {
+//        if (code == null || code.isBlank()) {
+//            throw new BusinessException(
+//                    ErrorCode.VALIDATION_ERROR,
+//                    "카카오 인증 실패 또는 취소",
+//                    java.util.Map.of(
+//                            "error", error,
+//                            "errorDescription", errorDescription
+//                    )
+//            );
+//        }
+//        return ApiResponse.ok(oauthService.kakaoLogin(code));
+//    }
 
-    // ✅ NEW: 프론트가 받은 code로 로그인 처리하는 API
+    // ✅ 프론트가 받은 code + redirectUri로 로그인 처리하는 API
     @PostMapping("/kakao/code")
-    public ApiResponse<?> kakaoCodeLogin(@RequestBody KakaoCodeRequest request, HttpServletResponse response) {
-        if (request.code() == null || request.code().isBlank()) {
+    public ApiResponse<?> kakaoCodeLogin(
+            @RequestBody KakaoCodeRequest request,
+            HttpServletResponse response
+    ) {
+        if (request == null || request.code() == null || request.code().isBlank()) {
             throw new BusinessException(ErrorCode.VALIDATION_ERROR, "code가 비어있습니다.", null);
         }
-        AuthResponse auth = oauthService.kakaoLogin(request.code());
+        if (request.redirectUri() == null || request.redirectUri().isBlank()) {
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "redirectUri가 비어있습니다.", null);
+        }
+
+        // ✅ code + redirectUri 같이 넘김
+        AuthResponse auth = oauthService.kakaoLogin(request.code(), request.redirectUri());
 
         // ✅ refresh token → HttpOnly 쿠키
         ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", auth.refreshToken())
                 .httpOnly(true)
-                .secure(false)          // 로컬 http면 false
+                .secure(false) // 로컬 http면 false
                 .path("/api/auth")
                 .sameSite("Lax")
                 .maxAge(60L * 60 * 24 * 14)
@@ -77,7 +85,7 @@ public class OAuthController {
 
         response.addHeader("Set-Cookie", refreshCookie.toString());
 
-        // ✅ 응답 바디에는 accessToken + account만 내려줌
+        // ✅ 응답 바디에는 accessToken + account만
         return ApiResponse.ok(
                 new KakaoLoginResponse(
                         auth.accessToken(),
@@ -86,7 +94,10 @@ public class OAuthController {
         );
     }
 
-    public record KakaoCodeRequest(String code) {}
+    public record KakaoCodeRequest(
+            String code,
+            String redirectUri
+    ) {}
 
     public record KakaoLoginResponse(
             String accessToken,

--- a/src/main/java/com/promlog/promlog/auth/infra/kakao/KakaoClient.java
+++ b/src/main/java/com/promlog/promlog/auth/infra/kakao/KakaoClient.java
@@ -21,14 +21,22 @@ public class KakaoClient {
         this.webClient = WebClient.builder().build();
     }
 
-    public KakaoTokenResponse exchangeToken(String code) {
+    // ✅ 변경: redirectUri를 파라미터로 받도록 수정
+    public KakaoTokenResponse exchangeToken(String code, String redirectUri) {
+
+        if (redirectUri == null || redirectUri.isBlank()) {
+            throw new BusinessException(
+                    ErrorCode.VALIDATION_ERROR,
+                    "redirectUri가 비어있습니다.",
+                    null
+            );
+        }
+
         MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
         form.add("grant_type", "authorization_code");
         form.add("client_id", props.clientId());
-        form.add("redirect_uri", props.redirectUri());
+        form.add("redirect_uri", redirectUri); // ✅ 여기 변경
         form.add("code", code);
-
-        // client_secret은 사용 안 함
 
         try {
             return webClient.post()
@@ -40,7 +48,11 @@ public class KakaoClient {
                     .bodyToMono(KakaoTokenResponse.class)
                     .block();
         } catch (Exception e) {
-            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "카카오 토큰 교환에 실패했습니다.", e.getMessage());
+            throw new BusinessException(
+                    ErrorCode.OAUTH_PROVIDER_ERROR,
+                    "카카오 토큰 교환에 실패했습니다.",
+                    e.getMessage()
+            );
         }
     }
 
@@ -54,7 +66,11 @@ public class KakaoClient {
                     .bodyToMono(KakaoUserInfoResponse.class)
                     .block();
         } catch (Exception e) {
-            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "카카오 유저 정보 조회에 실패했습니다.", e.getMessage());
+            throw new BusinessException(
+                    ErrorCode.OAUTH_PROVIDER_ERROR,
+                    "카카오 유저 정보 조회에 실패했습니다.",
+                    e.getMessage()
+            );
         }
     }
 }

--- a/src/main/java/com/promlog/promlog/auth/service/OAuthService.java
+++ b/src/main/java/com/promlog/promlog/auth/service/OAuthService.java
@@ -46,10 +46,18 @@ public class OAuthService {
     }
 
     @Transactional
-    public AuthResponse kakaoLogin(String code) {
+    public AuthResponse kakaoLogin(String code, String redirectUri) { // ✅ 변경: redirectUri 추가
+        if (redirectUri == null || redirectUri.isBlank()) {
+            throw new BusinessException(
+                    ErrorCode.VALIDATION_ERROR,
+                    "redirectUri가 비어있습니다.",
+                    Map.of("reason", "REDIRECT_URI_EMPTY")
+            );
+        }
+
         final KakaoUserInfoResponse me;
         try {
-            var token = kakaoClient.exchangeToken(code);
+            var token = kakaoClient.exchangeToken(code, redirectUri); // ✅ 변경: redirectUri 전달
             me = kakaoClient.getUserInfo(token.accessToken());
         } catch (BusinessException e) {
             throw e;
@@ -59,7 +67,10 @@ public class OAuthService {
             throw new BusinessException(
                     ErrorCode.OAUTH_PROVIDER_ERROR,
                     "카카오 로그인 처리 중 오류가 발생했습니다.",
-                    Map.of("reason", "KAKAO_API_ERROR")
+                    Map.of(
+                            "reason", "KAKAO_API_ERROR",
+                            "redirectUri", redirectUri
+                    )
             );
         }
 


### PR DESCRIPTION
## ✅ 체크리스트

- [x] 카카오 OAuth 로그인에 redirectUri 파라미터 지원 추가

## 📝 작업 상세 내용

카카오 OAuth 로그인에 redirectUri 파라미터 지원 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Kakao OAuth 인증 방식이 개선되어 인증 코드와 함께 리다이렉트 URI를 요청에 포함시켜야 합니다.

* **버그 수정**
  * OAuth 토큰 교환 시 리다이렉트 URI 검증이 강화되었습니다.
  * 외부 API 호출 실패 시 더 정확한 에러 메시지가 전달됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->